### PR TITLE
fix: remove LoadOnDemand directive from DragonWidgets.toc

### DIFF
--- a/DragonWidgets/DragonWidgets.toc
+++ b/DragonWidgets/DragonWidgets.toc
@@ -6,7 +6,6 @@
 ## Author: Xerrion
 ## Notes: Shared event-driven widget library for Dragon* addon Options panels
 ## Version: @project-version@
-## LoadOnDemand: 1
 
 DragonWidgets.lua
 LayoutConstants.lua


### PR DESCRIPTION
DragonWidgets is an embedded library - its TOC is only active in local development. `LoadOnDemand: 1` would prevent eager loading during standalone dev without any benefit. Removing it so the addon loads normally when symlinked into AddOns for development.

This does not affect production behavior since DragonWidgets is inlined into consumer `_Options` TOCs via the submodule path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated add-on configuration to use default loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->