### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -4,6 +4,7 @@ max_line_length = 120
 
 globals = {
     "DragonWidgetsNS",
+    "ColorPickerFrame",
 }
 
 read_globals = {
@@ -12,7 +13,6 @@ read_globals = {
     "UIParent",
     "UISpecialFrames",
     "GameTooltip",
-    "ColorPickerFrame",
     "ShowUIPanel",
     "PlaySound",
     "SOUNDKIT",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,152 @@
+# DragonWidgets - Agent Guidelines
+
+Project-specific guidelines for DragonWidgets. See the parent `../AGENTS.md` for general WoW addon development rules.
+
+DragonWidgets is a shared event-driven widget library for Dragon* addon options panels. It is embedded as a git submodule into `DragonLoot_Options` and `DragonToast_Options` — it is not a standalone addon in production. Its own TOC only matters during local standalone development.
+
+**GitHub**: https://github.com/Xerrion/DragonWidgets
+
+---
+
+## Skills
+
+Every `coder` delegation on this project must specify which skills to load. Use this matrix:
+
+| Skill                   | When to load                                                        |
+| ----------------------- | ------------------------------------------------------------------- |
+| `code-philosophy`         | All code changes (always)                                           |
+| `architecture-philosophy` | New widgets, file structure, namespace design, layer boundaries     |
+| `wow-lua-patterns`        | All WoW addon Lua (always)                                          |
+| `wow-frame-api`           | Any UI frame creation, widget layout, anchoring, backdrop, textures |
+
+Use the `wow-addon` agent (not `coder`) for WoW API research before implementation when API correctness is uncertain.
+
+---
+
+## Target Versions
+
+Retail, MoP Classic, TBC Anniversary, Cata Classic — all versions. No version-specific code in this library; it must work everywhere.
+
+---
+
+## Architecture
+
+DragonWidgets is a pure widget library. No Ace3, no SavedVariables, no slash commands. One global: `DragonWidgetsNS`.
+
+### File Map
+
+| File                          | Purpose                                          |
+| ----------------------------- | ------------------------------------------------ |
+| `DragonWidgets.lua`             | Bootstrap: `DragonWidgetsNS` global, event bus, `CreateOptionsPanel` factory |
+| `LayoutConstants.lua`           | Spacing constants used by consumer `_Options` tabs |
+| `Widgets/WidgetConstants.lua`   | Shared colors, fonts, textures used by all widgets |
+| `Widgets/Toggle.lua`            | Checkbox toggle with label and optional tooltip  |
+| `Widgets/Slider.lua`            | Numeric slider with label, fill bar, and tooltip |
+| `Widgets/Dropdown.lua`          | Dropdown menu with label and tooltip             |
+| `Widgets/ColorPicker.lua`       | Color swatch that opens the system color picker  |
+| `Widgets/Button.lua`            | Clickable button with label                      |
+| `Widgets/Header.lua`            | Section header label                             |
+| `Widgets/Description.lua`       | Multi-line description text block                |
+| `Widgets/Panel.lua`             | Options panel frame                              |
+| `Widgets/Section.lua`           | Collapsible section container                    |
+| `Widgets/ScrollFrame.lua`       | Scrollable content frame                         |
+| `Widgets/TabGroup.lua`          | Tab group for switching between option pages     |
+| `Widgets/ItemList.lua`          | List widget for item entries                     |
+| `Widgets/ItemSlot.lua`          | Single item slot widget                          |
+| `Widgets/TextInput.lua`         | Text input field                                 |
+
+### Namespace Pattern
+
+DragonWidgets uses a single global namespace table (not the `local ADDON_NAME, ns = ...` pattern, since this is a library):
+
+```lua
+local ns = DragonWidgetsNS
+local WC = ns.WidgetConstants
+```
+
+### Event Bus
+
+All widgets fire events via `ns.Fire(event, payload)`. Consumers subscribe with `ns.On(event, fn)`.
+
+| Event              | Fired by             | Payload                                      |
+| ------------------ | -------------------- | -------------------------------------------- |
+| `OnWidgetChanged`    | All value widgets    | `{ widgetType, key, value }`                   |
+| `OnAppearanceChanged`| Toggle (isAppearance)| `{}`                                         |
+| `OnPanelOpened`      | Panel factory        | `{ panelName }`                               |
+| `OnPanelClosed`      | Panel factory        | `{ panelName }`                               |
+
+### Widget API Contract
+
+All widgets return a `frame` with a public API:
+
+| Method            | All widgets | Description                          |
+| ----------------- | ----------- | ------------------------------------ |
+| `frame:GetValue()`  | Toggle, Slider, ColorPicker, Dropdown | Returns current value |
+| `frame:SetValue(v)` | Toggle, Slider, ColorPicker, Dropdown | Sets value without firing event |
+| `frame:SetDisabled(bool)` | All | Enable/disable the widget      |
+| `frame:Refresh()`   | All         | Re-reads from `opts.get()`           |
+
+---
+
+## Deployment Model
+
+DragonWidgets is **never loaded via its own TOC in production**. Consumer `_Options` addons list every DragonWidgets `.lua` file path explicitly in their TOC. The `DragonWidgets.toc` is only active during local standalone development.
+
+```
+# DragonLoot_Options.toc (example)
+Libs\DragonWidgets\DragonWidgets\DragonWidgets.lua
+Libs\DragonWidgets\DragonWidgets\LayoutConstants.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\WidgetConstants.lua
+Libs\DragonWidgets\DragonWidgets\Widgets\Toggle.lua
+...
+```
+
+When adding a new widget file, it must be added to every consumer TOC that needs it.
+
+---
+
+## Build, Lint & Test
+
+```bash
+# Lint
+cd /mnt/Develop/wow-addons/DragonWidgets
+luacheck .
+```
+
+No automated tests currently. See issue #4 for the busted test framework plan.
+
+---
+
+## GitHub Workflow
+
+### Issues
+- Title format: `[Bug]: description` / `[Feature]: description`
+- Always apply: one `C-*` (category), one `A-*` (area), one `D-*` (difficulty), one `P-*` (platform) label
+- Use the repo's GitHub issue templates (bug-report or feature-request)
+- Add new issues to the appropriate project and set status to **"To triage"**
+
+### GitHub Projects
+- **DragonWidgets - Bugs**: project #8 (`C-Bug` issues)
+- **DragonWidgets - Feature Requests**: project #9 (`C-Feature` issues)
+- Status columns: **To triage -> Backlog -> Ready -> In progress -> In review -> Done**
+
+### Branching and PRs
+- Branch from `master`: `feat/<number>-short-desc`, `fix/<number>-short-desc`, `refactor/<number>-short-desc`
+- One PR per issue; reference `Closes #N` in the PR body
+- Squash merge only: `gh pr merge <N> --squash --delete-branch`
+- **Never merge release-please PRs** (`chore(master): release X.Y.Z`) - the repo owner merges these manually
+- Wait for CodeRabbit AI review before merging; reply to comments with `@coderabbitai` in the specific thread
+
+### Commits
+- Conventional Commits: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`
+- Reference issue numbers: `fix: toggle box area now registers clicks (#2)`
+
+---
+
+## Known Gotchas
+
+1. **Child Frame mouse interception** - Child `Frame` widgets intercept mouse events from their parent. If a visual element is a `Frame` (not a texture), it must either have its own `OnMouseUp` handler or call `EnableMouse(false)` to pass clicks through to the parent.
+2. **FontString cannot receive mouse events** - Labels are `FontString` regions; they cannot register click scripts. Click areas must be covered by the parent `Frame`.
+3. **No Ace3** - Do not add Ace3 or any external library. This library must remain dependency-free.
+4. **Consumer TOC maintenance** - Adding a new `.lua` file requires updating every consumer `_Options` TOC manually.
+5. **`DragonWidgetsNS` is the only global** - Never introduce additional globals.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,21 +8,6 @@ DragonWidgets is a shared event-driven widget library for Dragon* addon options 
 
 ---
 
-## Skills
-
-Every `coder` delegation on this project must specify which skills to load. Use this matrix:
-
-| Skill                   | When to load                                                        |
-| ----------------------- | ------------------------------------------------------------------- |
-| `code-philosophy`         | All code changes (always)                                           |
-| `architecture-philosophy` | New widgets, file structure, namespace design, layer boundaries     |
-| `wow-lua-patterns`        | All WoW addon Lua (always)                                          |
-| `wow-frame-api`           | Any UI frame creation, widget layout, anchoring, backdrop, textures |
-
-Use the `wow-addon` agent (not `coder`) for WoW API research before implementation when API correctness is uncertain.
-
----
-
 ## Target Versions
 
 Retail, MoP Classic, TBC Anniversary, Cata Classic — all versions. No version-specific code in this library; it must work everywhere.
@@ -31,7 +16,7 @@ Retail, MoP Classic, TBC Anniversary, Cata Classic — all versions. No version-
 
 ## Architecture
 
-DragonWidgets is a pure widget library. No Ace3, no SavedVariables, no slash commands. One global: `DragonWidgetsNS`.
+DragonWidgets is a pure widget library. No Ace3, no SavedVariables, no slash commands. One global: `DragonWidgetsNS`. Use the `wow-addon` agent for WoW API research before implementation when API correctness is uncertain.
 
 ### File Map
 
@@ -105,41 +90,10 @@ When adding a new widget file, it must be added to every consumer TOC that needs
 
 ---
 
-## Build, Lint & Test
+## GitHub Projects
 
-```bash
-# Lint
-cd /mnt/Develop/wow-addons/DragonWidgets
-luacheck .
-```
-
-No automated tests currently. See issue #4 for the busted test framework plan.
-
----
-
-## GitHub Workflow
-
-### Issues
-- Title format: `[Bug]: description` / `[Feature]: description`
-- Always apply: one `C-*` (category), one `A-*` (area), one `D-*` (difficulty), one `P-*` (platform) label
-- Use the repo's GitHub issue templates (bug-report or feature-request)
-- Add new issues to the appropriate project and set status to **"To triage"**
-
-### GitHub Projects
 - **DragonWidgets - Bugs**: project #8 (`C-Bug` issues)
 - **DragonWidgets - Feature Requests**: project #9 (`C-Feature` issues)
-- Status columns: **To triage -> Backlog -> Ready -> In progress -> In review -> Done**
-
-### Branching and PRs
-- Branch from `master`: `feat/<number>-short-desc`, `fix/<number>-short-desc`, `refactor/<number>-short-desc`
-- One PR per issue; reference `Closes #N` in the PR body
-- Squash merge only: `gh pr merge <N> --squash --delete-branch`
-- **Never merge release-please PRs** (`chore(master): release X.Y.Z`) - the repo owner merges these manually
-- Wait for CodeRabbit AI review before merging; reply to comments with `@coderabbitai` in the specific thread
-
-### Commits
-- Conventional Commits: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`
-- Reference issue numbers: `fix: toggle box area now registers clicks (#2)`
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,12 +64,12 @@ All widgets fire events via `ns.Fire(event, payload)`. Consumers subscribe with 
 
 All widgets return a `frame` with a public API:
 
-| Method            | All widgets | Description                          |
-| ----------------- | ----------- | ------------------------------------ |
-| `frame:GetValue()`  | Toggle, Slider, ColorPicker, Dropdown | Returns current value |
-| `frame:SetValue(v)` | Toggle, Slider, ColorPicker, Dropdown | Sets value without firing event |
-| `frame:SetDisabled(bool)` | All | Enable/disable the widget      |
-| `frame:Refresh()`   | All         | Re-reads from `opts.get()`           |
+| Method            | Implemented by | Description                          |
+| ----------------- | -------------- | ------------------------------------ |
+| `frame:GetValue()`  | Toggle, Slider, ColorPicker, Dropdown, TextInput, ItemList | Returns current value |
+| `frame:SetValue(v)` | Toggle, Slider, ColorPicker, Dropdown, TextInput, ItemList | Sets value without firing event |
+| `frame:SetDisabled(bool)` | Toggle, Slider, ColorPicker, Dropdown, TextInput, ItemList | Enable/disable the widget |
+| `frame:Refresh()`   | Toggle, Slider, ColorPicker, Dropdown, TextInput, ItemList | Re-reads from `opts.get()` |
 
 ---
 
@@ -101,6 +101,6 @@ When adding a new widget file, it must be added to every consumer TOC that needs
 
 1. **Child Frame mouse interception** - Child `Frame` widgets intercept mouse events from their parent. If a visual element is a `Frame` (not a texture), it must either have its own `OnMouseUp` handler or call `EnableMouse(false)` to pass clicks through to the parent.
 2. **FontString cannot receive mouse events** - Labels are `FontString` regions; they cannot register click scripts. Click areas must be covered by the parent `Frame`.
-3. **No Ace3** - Do not add Ace3 or any external library. This library must remain dependency-free.
+3. **No Ace3** - Do not add Ace3 or any external library. No hard library dependencies. LibSharedMedia-3.0 is soft-loaded (`LibStub("LibSharedMedia-3.0", true)`) and only used for media-type dropdowns; absent LSM falls back to empty lists.
 4. **Consumer TOC maintenance** - Adding a new `.lua` file requires updating every consumer `_Options` TOC manually.
 5. **`DragonWidgetsNS` is the only global** - Never introduce additional globals.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Project-specific guidelines for DragonWidgets. See the parent `../AGENTS.md` for general WoW addon development rules.
 
-DragonWidgets is a shared event-driven widget library for Dragon* addon options panels. It is embedded as a git submodule into `DragonLoot_Options` and `DragonToast_Options` — it is not a standalone addon in production. Its own TOC only matters during local standalone development.
+DragonWidgets is a shared event-driven widget library for Dragon* addon options panels. It is embedded as a git submodule into `DragonLoot_Options` and `DragonToast_Options` - it is not a standalone addon in production. Its own TOC only matters during local standalone development.
 
 **GitHub**: https://github.com/Xerrion/DragonWidgets
 
@@ -10,7 +10,7 @@ DragonWidgets is a shared event-driven widget library for Dragon* addon options 
 
 ## Target Versions
 
-Retail, MoP Classic, TBC Anniversary, Cata Classic — all versions. No version-specific code in this library; it must work everywhere.
+Retail, MoP Classic, TBC Anniversary, Cata Classic - all versions. No version-specific code in this library; it must work everywhere.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,9 +71,9 @@ All widgets fire events via `ns.Fire(event, payload)`. Consumers subscribe with 
 | Event              | Fired by             | Payload                                      |
 | ------------------ | -------------------- | -------------------------------------------- |
 | `OnWidgetChanged`    | All value widgets    | `{ widgetType, key, value }`                   |
-| `OnAppearanceChanged`| Toggle (isAppearance)| `{}`                                         |
-| `OnPanelOpened`      | Panel factory        | `{ panelName }`                               |
-| `OnPanelClosed`      | Panel factory        | `{ panelName }`                               |
+| `OnAppearanceChanged`| Any widget with `opts.isAppearance = true`; also LayoutConstants | `{}`                                         |
+| `OnPanelOpened`      | Panel factory        | `{}`                                          |
+| `OnPanelClosed`      | Panel factory        | `{}`                                          |
 
 ### Widget API Contract
 

--- a/DragonWidgets/Widgets/ColorPicker.lua
+++ b/DragonWidgets/Widgets/ColorPicker.lua
@@ -13,7 +13,6 @@ local WC = ns.WidgetConstants
 -------------------------------------------------------------------------------
 
 local CreateFrame = CreateFrame
-local ColorPickerFrame = ColorPickerFrame
 local ShowUIPanel = ShowUIPanel
 
 -------------------------------------------------------------------------------
@@ -179,18 +178,18 @@ function ns.Widgets.CreateColorPicker(parent, opts)
     end)
 
     -- Public API
-    function frame:GetValue()
+    function frame.GetValue(_)
         if opts.get then return opts.get() end
         return initR, initG, initB, initA
     end
 
-    function frame:SetValue(r, g, b, a)
+    function frame.SetValue(_, r, g, b, a)
         a = a or 1
         UpdateSwatch(swatch, r, g, b, a)
         if opts.set then opts.set(r, g, b, a) end
     end
 
-    function frame:SetDisabled(state)
+    function frame.SetDisabled(_, state)
         disabled = state
         if disabled then
             label:SetTextColor(DISABLED_COLOR[1], DISABLED_COLOR[2], DISABLED_COLOR[3])
@@ -201,7 +200,7 @@ function ns.Widgets.CreateColorPicker(parent, opts)
         end
     end
 
-    function frame:Refresh()
+    function frame.Refresh(_)
         if not opts.get then return end
         local r, g, b, a = opts.get()
         UpdateSwatch(swatch, r, g, b, a or 1)

--- a/DragonWidgets/Widgets/Dropdown.lua
+++ b/DragonWidgets/Widgets/Dropdown.lua
@@ -421,18 +421,18 @@ function ns.Widgets.CreateDropdown(parent, opts)
     UpdateSelectedPreview(frame, opts, initKey)
 
     -- Public API
-    function frame:GetValue()
+    function frame.GetValue(_)
         return opts.get and opts.get() or nil
     end
 
-    function frame:SetValue(v)
+    function frame.SetValue(_, v)
         if opts.set then opts.set(v) end
         local vals = ResolveValues(opts)
         selectedText:SetText(FindDisplayText(vals, v))
         UpdateSelectedPreview(frame, opts, v)
     end
 
-    function frame:SetDisabled(state)
+    function frame.SetDisabled(_, state)
         disabled = state
         button:SetBackdropColor(BG_COLOR[1], BG_COLOR[2], BG_COLOR[3], BG_COLOR[4])
         if disabled then
@@ -449,7 +449,7 @@ function ns.Widgets.CreateDropdown(parent, opts)
         end
     end
 
-    function frame:Refresh()
+    function frame.Refresh(_)
         local vals = ResolveValues(opts)
         local key = opts.get and opts.get() or nil
         selectedText:SetText(FindDisplayText(vals, key))

--- a/DragonWidgets/Widgets/ItemList.lua
+++ b/DragonWidgets/Widgets/ItemList.lua
@@ -272,7 +272,7 @@ function ns.Widgets.CreateItemList(parent, opts)
     end
 
     -- Public API: GetValue / SetValue / SetDisabled for consistency
-    function frame:GetValue()
+    function frame.GetValue(_)
         return opts.getItems and opts.getItems() or {}
     end
 

--- a/DragonWidgets/Widgets/Slider.lua
+++ b/DragonWidgets/Widgets/Slider.lua
@@ -271,11 +271,11 @@ function ns.Widgets.CreateSlider(parent, opts)
     UpdateFillWidth(currentValue)
 
     -- Public API
-    function frame:GetValue()
+    function frame.GetValue(_)
         return currentValue
     end
 
-    function frame:SetValue(v)
+    function frame.SetValue(_, v)
         local clamped = Clamp(RoundToStep(v, step), minVal, maxVal)
         currentValue = clamped
         isInternal = true
@@ -285,7 +285,7 @@ function ns.Widgets.CreateSlider(parent, opts)
         UpdateFillWidth(clamped)
     end
 
-    function frame:SetDisabled(state)
+    function frame.SetDisabled(_, state)
         disabled = state
         slider:EnableMouse(not disabled)
         editBox:EnableMouse(not disabled)
@@ -300,7 +300,7 @@ function ns.Widgets.CreateSlider(parent, opts)
         end
     end
 
-    function frame:Refresh()
+    function frame.Refresh(_)
         if opts.get then
             local v = opts.get() or minVal
             local clamped = Clamp(RoundToStep(v, step), minVal, maxVal)

--- a/DragonWidgets/Widgets/TabGroup.lua
+++ b/DragonWidgets/Widgets/TabGroup.lua
@@ -193,7 +193,7 @@ function ns.Widgets.CreateTabGroup(parent, tabs)
     tabBar:SetScript("OnSizeChanged", ResizeTabs)
 
     -- SelectTab: switch to a tab, lazy-create content on first visit
-    function tabGroup:SelectTab(id)
+    function tabGroup.SelectTab(_, id)
         if selectedTab == id then return end
 
         -- Deselect previous
@@ -232,7 +232,7 @@ function ns.Widgets.CreateTabGroup(parent, tabs)
         contentFrames[id]:Show()
     end
 
-    function tabGroup:GetSelectedTab()
+    function tabGroup.GetSelectedTab(_)
         return selectedTab
     end
 

--- a/DragonWidgets/Widgets/TextInput.lua
+++ b/DragonWidgets/Widgets/TextInput.lua
@@ -103,15 +103,15 @@ function ns.Widgets.CreateTextInput(parent, opts)
     end
 
     -- Public API
-    function frame:GetValue()
+    function frame.GetValue(_)
         return editBox:GetText()
     end
 
-    function frame:SetValue(v)
+    function frame.SetValue(_, v)
         editBox:SetText(v or "")
     end
 
-    function frame:SetDisabled(state)
+    function frame.SetDisabled(_, state)
         disabled = state
         if disabled then
             label:SetTextColor(DISABLED_COLOR[1], DISABLED_COLOR[2], DISABLED_COLOR[3])
@@ -122,7 +122,7 @@ function ns.Widgets.CreateTextInput(parent, opts)
         end
     end
 
-    function frame:Refresh()
+    function frame.Refresh(_)
         if opts.get then
             editBox:SetText(opts.get() or "")
         end

--- a/DragonWidgets/Widgets/Toggle.lua
+++ b/DragonWidgets/Widgets/Toggle.lua
@@ -137,17 +137,17 @@ function ns.Widgets.CreateToggle(parent, opts)
     end
 
     -- Public API
-    function frame:GetValue()
+    function frame.GetValue(_)
         return checked
     end
 
-    function frame:SetValue(v)
+    function frame.SetValue(_, v)
         checked = not not v
         box._checkMark:SetShown(checked)
         UpdateCheckBorder(box, checked)
     end
 
-    function frame:SetDisabled(state)
+    function frame.SetDisabled(_, state)
         disabled = state
         if disabled then
             label:SetTextColor(DISABLED_COLOR[1], DISABLED_COLOR[2], DISABLED_COLOR[3])
@@ -158,7 +158,7 @@ function ns.Widgets.CreateToggle(parent, opts)
         end
     end
 
-    function frame:Refresh()
+    function frame.Refresh(_)
         if opts.get then
             checked = not not opts.get()
             box._checkMark:SetShown(checked)


### PR DESCRIPTION
Adds AGENTS.md with architecture overview, widget API contract, deployment model, GitHub workflow (projects #8/#9, labels), and known gotchas.

Notable: documents the child-frame mouse interception gotcha (issue #2) and the planned busted test framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive DragonWidgets contributor and usage guidelines, API contracts, deployment notes, and known UI limitations.
* **Breaking Change — Widget APIs**
  * Widget public methods now use explicit function-call signatures; consumers should update calls to the new invocation style for ColorPicker, Dropdown, ItemList, Slider, TabGroup, TextInput, and Toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->