### PR TITLE
fix: toggle checkbox box area not clickable (#2)

### DIFF
--- a/DragonWidgets/Widgets/Toggle.lua
+++ b/DragonWidgets/Widgets/Toggle.lua
@@ -142,16 +142,26 @@ function ns.Widgets.CreateToggle(parent, opts)
     end
 
     -- Public API
+
+    --- Returns the current checked state of the toggle.
+    ---@return boolean checked Whether the toggle is currently checked
     function frame.GetValue(_)
         return checked
     end
 
+    --- Sets the checked state without firing change events.
+    ---@param _ any Self reference (unused, dot-style call)
+    ---@param v boolean The new checked state (coerced to boolean)
     function frame.SetValue(_, v)
         checked = not not v
         box._checkMark:SetShown(checked)
         UpdateCheckBorder(box, checked)
     end
 
+    --- Enables or disables the toggle widget.
+    --- When disabled, the label is dimmed and clicks are ignored.
+    ---@param _ any Self reference (unused, dot-style call)
+    ---@param state boolean True to disable, false to enable
     function frame.SetDisabled(_, state)
         disabled = state
         box:SetBackdropColor(WC.WIDGET_BG[1], WC.WIDGET_BG[2], WC.WIDGET_BG[3], WC.WIDGET_BG[4])
@@ -164,6 +174,8 @@ function ns.Widgets.CreateToggle(parent, opts)
         end
     end
 
+    --- Refreshes the visual state by re-reading from opts.get().
+    --- No-op if opts.get was not provided at creation time.
     function frame.Refresh(_)
         if opts.get then
             checked = not not opts.get()

--- a/DragonWidgets/Widgets/Toggle.lua
+++ b/DragonWidgets/Widgets/Toggle.lua
@@ -96,23 +96,12 @@ function ns.Widgets.CreateToggle(parent, opts)
     -- Tooltip
     frame._tooltipText = opts.tooltip
 
-    -- Hover state on checkbox
-    box:SetScript("OnEnter", function()
-        if disabled then return end
-        box:SetBackdropColor(
-            WC.WIDGET_BG_HOVER[1], WC.WIDGET_BG_HOVER[2],
-            WC.WIDGET_BG_HOVER[3], WC.WIDGET_BG_HOVER[4]
-        )
-    end)
-    box:SetScript("OnLeave", function()
-        box:SetBackdropColor(WC.WIDGET_BG[1], WC.WIDGET_BG[2], WC.WIDGET_BG[3], WC.WIDGET_BG[4])
-    end)
+    -- Disable mouse on box so clicks pass through to the parent frame
+    box:EnableMouse(false)
 
-    -- Click handler on the entire frame
-    frame:EnableMouse(true)
-    frame:SetScript("OnEnter", WC.ShowTooltip)
-    frame:SetScript("OnLeave", WC.HideTooltip)
-    frame:SetScript("OnMouseUp", function()
+    -- Toggle logic (sole handler lives on frame)
+    local function doToggle(_, button)
+        if button ~= "LeftButton" then return end
         if disabled then return end
         checked = not checked
         box._checkMark:SetShown(checked)
@@ -120,7 +109,23 @@ function ns.Widgets.CreateToggle(parent, opts)
         if opts.set then opts.set(checked) end
         ns.Fire("OnWidgetChanged", { widgetType = "Toggle", key = opts.key, value = checked })
         if opts.isAppearance then ns.Fire("OnAppearanceChanged", {}) end
+    end
+
+    -- Frame handles tooltip, hover highlight, and click
+    frame:EnableMouse(true)
+    frame:SetScript("OnEnter", function(self)
+        WC.ShowTooltip(self)
+        if disabled then return end
+        box:SetBackdropColor(
+            WC.WIDGET_BG_HOVER[1], WC.WIDGET_BG_HOVER[2],
+            WC.WIDGET_BG_HOVER[3], WC.WIDGET_BG_HOVER[4]
+        )
     end)
+    frame:SetScript("OnLeave", function()
+        WC.HideTooltip()
+        box:SetBackdropColor(WC.WIDGET_BG[1], WC.WIDGET_BG[2], WC.WIDGET_BG[3], WC.WIDGET_BG[4])
+    end)
+    frame:SetScript("OnMouseUp", doToggle)
 
     -- Initialize from opts.get
     if opts.get then
@@ -149,6 +154,7 @@ function ns.Widgets.CreateToggle(parent, opts)
 
     function frame.SetDisabled(_, state)
         disabled = state
+        box:SetBackdropColor(WC.WIDGET_BG[1], WC.WIDGET_BG[2], WC.WIDGET_BG[3], WC.WIDGET_BG[4])
         if disabled then
             label:SetTextColor(DISABLED_COLOR[1], DISABLED_COLOR[2], DISABLED_COLOR[3])
             box:SetAlpha(0.5)


### PR DESCRIPTION
## Summary

Fixes #2 - clicking directly on the toggle checkbox square had no effect; only the label text area registered clicks.

## Root Cause

The `box` Frame (the checkbox square) had `OnEnter`/`OnLeave` scripts registered, which implicitly mouse-enabled it. A mouse-enabled child Frame silently consumes mouse events in WoW's UI stack - clicks on the box never propagated to the parent `frame`'s `OnMouseUp` handler where the toggle logic lived.

## Fix

- `box:EnableMouse(false)` - box is now click-transparent; all mouse events reach the parent `frame`
- Hover effects (backdrop color highlight) moved from `box`'s `OnEnter`/`OnLeave` to `frame`'s handlers
- `doToggle(_, button)` extracted as a named local with `LeftButton` guard - prevents right-click from toggling
- `SetDisabled` now resets backdrop color unconditionally (both enable and disable paths)
- `OnLeave` resets backdrop unconditionally (no disabled guard needed - disabled visual is carried by `box:SetAlpha`)

## Type of change
- [x] Bug fix

## Testing
- Test by clicking directly on the checkbox square - state should now toggle
- Test by clicking on the label text - state should still toggle
- Test right-click on toggle - state should NOT change
- Test `SetDisabled(true)` while cursor is over toggle - hover tint should clear
- Test `SetDisabled(false)` while cursor is over toggle - should restore to default background

## Checklist
- [x] luacheck passes (0 warnings / 0 errors)
- [x] No new globals introduced
- [x] Behavior preserved for all callers (colon-call `frame:GetValue()` etc. still work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated toggle interaction: clicks and hover/tooltip handling are unified for more consistent behavior.
  * Hover and tooltip responsibilities moved to the toggle container for reliable display.
  * Improved disabled-state visuals: backdrop, label color, and checkmark appearance now update more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->