### PR TITLE
feat: add busted test infrastructure with EventBus and Toggle tests (#4)

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,10 @@
+return {
+    _all = {
+        lua = "lua",
+    },
+    default = {
+        ROOT = { "spec" },
+        pattern = "_spec",
+        verbose = true,
+    },
+}

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,10 @@
+[tools]
+lua = "5.1"
+
+[tasks.test]
+run = "busted --verbose"
+description = "Run busted test suite"
+
+[tasks.lint]
+run = "luacheck ."
+description = "Run luacheck linter"

--- a/spec/EventBus_spec.lua
+++ b/spec/EventBus_spec.lua
@@ -1,0 +1,87 @@
+-------------------------------------------------------------------------------
+-- EventBus_spec.lua
+-- Tests for ns.On / ns.Fire event bus in DragonWidgets.lua
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("EventBus", function()
+    local ns
+
+    before_each(function()
+        ns = mock.Reload()
+    end)
+
+    describe("ns.Fire", function()
+        it("does not error when no listeners are registered", function()
+            assert.has_no.errors(function()
+                ns.Fire("SomeEvent", { foo = "bar" })
+            end)
+        end)
+
+        it("passes empty table when payload is nil", function()
+            local receivedPayload
+            ns.On("TestEvent", function(payload)
+                receivedPayload = payload
+            end)
+
+            ns.Fire("TestEvent")
+
+            assert.is_table(receivedPayload)
+            assert.are.same({}, receivedPayload)
+        end)
+
+        it("passes payload table correctly to all listeners", function()
+            local receivedA, receivedB
+            ns.On("TestEvent", function(payload)
+                receivedA = payload
+            end)
+            ns.On("TestEvent", function(payload)
+                receivedB = payload
+            end)
+
+            local sentPayload = { widgetType = "Toggle", key = "myKey", value = true }
+            ns.Fire("TestEvent", sentPayload)
+
+            assert.are.same(sentPayload, receivedA)
+            assert.are.same(sentPayload, receivedB)
+        end)
+    end)
+
+    describe("ns.On", function()
+        it("registers a listener that fires on ns.Fire", function()
+            local wasCalled = false
+            ns.On("WidgetChanged", function()
+                wasCalled = true
+            end)
+
+            ns.Fire("WidgetChanged", {})
+
+            assert.is_true(wasCalled)
+        end)
+
+        it("supports multiple listeners on the same event", function()
+            local callCount = 0
+            ns.On("MultiEvent", function() callCount = callCount + 1 end)
+            ns.On("MultiEvent", function() callCount = callCount + 1 end)
+            ns.On("MultiEvent", function() callCount = callCount + 1 end)
+
+            ns.Fire("MultiEvent", {})
+
+            assert.are.equal(3, callCount)
+        end)
+
+        it("does not cross-fire between different events", function()
+            local alphaFired = false
+            local betaFired = false
+
+            ns.On("Alpha", function() alphaFired = true end)
+            ns.On("Beta", function() betaFired = true end)
+
+            ns.Fire("Alpha", {})
+
+            assert.is_true(alphaFired)
+            assert.is_false(betaFired)
+        end)
+    end)
+end)

--- a/spec/Toggle_spec.lua
+++ b/spec/Toggle_spec.lua
@@ -1,0 +1,251 @@
+-------------------------------------------------------------------------------
+-- Toggle_spec.lua
+-- Tests for ns.Widgets.CreateToggle
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Toggle", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("Toggle.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    -------------------------------------------------------------------------------
+    -- GetValue
+    -------------------------------------------------------------------------------
+
+    describe("GetValue", function()
+        it("returns false initially when no opts.get is provided", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+            })
+
+            assert.is_false(toggle:GetValue())
+        end)
+
+        it("returns true when initialized with opts.get returning true", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+                get = function() return true end,
+            })
+
+            assert.is_true(toggle:GetValue())
+        end)
+    end)
+
+    -------------------------------------------------------------------------------
+    -- SetValue
+    -------------------------------------------------------------------------------
+
+    describe("SetValue", function()
+        it("sets checked state to true", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+            })
+
+            toggle:SetValue(true)
+
+            assert.is_true(toggle:GetValue())
+        end)
+
+        it("sets checked state to false", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+                get = function() return true end,
+            })
+
+            toggle:SetValue(false)
+
+            assert.is_false(toggle:GetValue())
+        end)
+
+        it("coerces truthy value (1) to true", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+            })
+
+            toggle:SetValue(1)
+
+            assert.is_true(toggle:GetValue())
+        end)
+
+        it("does NOT call opts.set", function()
+            local setCalled = false
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+                set = function() setCalled = true end,
+            })
+
+            toggle:SetValue(true)
+
+            assert.is_false(setCalled)
+        end)
+    end)
+
+    -------------------------------------------------------------------------------
+    -- Click behavior (OnMouseUp)
+    -------------------------------------------------------------------------------
+
+    describe("clicking", function()
+        it("toggles state from false to true on LeftButton", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+            })
+
+            local onMouseUp = toggle._scripts["OnMouseUp"]
+            onMouseUp(toggle, "LeftButton")
+
+            assert.is_true(toggle:GetValue())
+        end)
+
+        it("does NOT toggle state on RightButton", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+            })
+
+            local onMouseUp = toggle._scripts["OnMouseUp"]
+            onMouseUp(toggle, "RightButton")
+
+            assert.is_false(toggle:GetValue())
+        end)
+
+        it("calls opts.set with new value on click", function()
+            local receivedValue
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+                set = function(v) receivedValue = v end,
+            })
+
+            local onMouseUp = toggle._scripts["OnMouseUp"]
+            onMouseUp(toggle, "LeftButton")
+
+            assert.is_true(receivedValue)
+        end)
+
+        it("fires OnWidgetChanged event with correct payload", function()
+            local receivedPayload
+            ns.On("OnWidgetChanged", function(payload)
+                receivedPayload = payload
+            end)
+
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "myToggleKey",
+            })
+
+            local onMouseUp = toggle._scripts["OnMouseUp"]
+            onMouseUp(toggle, "LeftButton")
+
+            assert.is_not_nil(receivedPayload)
+            assert.are.equal("Toggle", receivedPayload.widgetType)
+            assert.are.equal("myToggleKey", receivedPayload.key)
+            assert.is_true(receivedPayload.value)
+        end)
+
+        it("fires OnAppearanceChanged when opts.isAppearance is true", function()
+            local appearanceFired = false
+            ns.On("OnAppearanceChanged", function()
+                appearanceFired = true
+            end)
+
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+                isAppearance = true,
+            })
+
+            local onMouseUp = toggle._scripts["OnMouseUp"]
+            onMouseUp(toggle, "LeftButton")
+
+            assert.is_true(appearanceFired)
+        end)
+
+        it("does NOT fire OnAppearanceChanged when opts.isAppearance is nil", function()
+            local appearanceFired = false
+            ns.On("OnAppearanceChanged", function()
+                appearanceFired = true
+            end)
+
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+            })
+
+            local onMouseUp = toggle._scripts["OnMouseUp"]
+            onMouseUp(toggle, "LeftButton")
+
+            assert.is_false(appearanceFired)
+        end)
+    end)
+
+    -------------------------------------------------------------------------------
+    -- SetDisabled
+    -------------------------------------------------------------------------------
+
+    describe("SetDisabled", function()
+        it("prevents clicking from changing state when disabled", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+            })
+
+            toggle:SetDisabled(true)
+
+            local onMouseUp = toggle._scripts["OnMouseUp"]
+            onMouseUp(toggle, "LeftButton")
+
+            assert.is_false(toggle:GetValue())
+        end)
+
+        it("re-enables clicking after SetDisabled(false)", function()
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+            })
+
+            toggle:SetDisabled(true)
+            toggle:SetDisabled(false)
+
+            local onMouseUp = toggle._scripts["OnMouseUp"]
+            onMouseUp(toggle, "LeftButton")
+
+            assert.is_true(toggle:GetValue())
+        end)
+    end)
+
+    -------------------------------------------------------------------------------
+    -- Refresh
+    -------------------------------------------------------------------------------
+
+    describe("Refresh", function()
+        it("re-reads from opts.get", function()
+            local externalValue = false
+            local toggle = ns.Widgets.CreateToggle(parentFrame, {
+                label = "Test Toggle",
+                key = "testKey",
+                get = function() return externalValue end,
+            })
+
+            assert.is_false(toggle:GetValue())
+
+            externalValue = true
+            toggle:Refresh()
+
+            assert.is_true(toggle:GetValue())
+        end)
+    end)
+end)

--- a/spec/wow_mock.lua
+++ b/spec/wow_mock.lua
@@ -1,0 +1,269 @@
+-------------------------------------------------------------------------------
+-- wow_mock.lua
+-- Lightweight WoW API mock for DragonWidgets busted unit tests
+-------------------------------------------------------------------------------
+
+local M = {}
+
+-- luacheck: push ignore 121 122
+
+-------------------------------------------------------------------------------
+-- GameTooltip stub
+-------------------------------------------------------------------------------
+
+GameTooltip = {
+    SetOwner = function() end,
+    SetText = function() end,
+    Show = function() end,
+    Hide = function() end,
+}
+
+-------------------------------------------------------------------------------
+-- UISpecialFrames (used by CreateOptionsPanel)
+-------------------------------------------------------------------------------
+
+UISpecialFrames = {}
+
+-------------------------------------------------------------------------------
+-- LibStub mock (returns nil - LSM is soft-loaded)
+-------------------------------------------------------------------------------
+
+function LibStub()
+    return nil
+end
+
+-------------------------------------------------------------------------------
+-- Sound / misc WoW API stubs
+-------------------------------------------------------------------------------
+
+function PlaySound() end
+
+SOUNDKIT = {}
+
+UIParent = nil -- set after CreateFrame is defined
+
+-------------------------------------------------------------------------------
+-- Mock texture
+-------------------------------------------------------------------------------
+
+local function CreateMockTexture()
+    local tex = {
+        _shown = true,
+    }
+
+    function tex.SetTexture() end
+    function tex.SetPoint() end
+    function tex.SetSize() end
+    function tex.SetAllPoints() end
+    function tex.SetTexCoord() end
+    function tex.SetVertexColor() end
+    function tex.SetColorTexture() end
+
+    function tex:Hide()
+        self._shown = false
+    end
+
+    function tex:Show()
+        self._shown = true
+    end
+
+    function tex:SetShown(isShown)
+        self._shown = not not isShown
+    end
+
+    function tex:IsShown()
+        return self._shown
+    end
+
+    return tex
+end
+
+-------------------------------------------------------------------------------
+-- Mock font string
+-------------------------------------------------------------------------------
+
+local function CreateMockFontString()
+    local fs = {
+        _text = "",
+        _font = nil,
+        _fontSize = 12,
+    }
+
+    function fs.SetFont(_, font, size)
+        fs._font = font
+        fs._fontSize = size
+    end
+
+    function fs.SetTextColor() end
+    function fs.SetPoint() end
+    function fs.SetJustifyH() end
+    function fs.SetJustifyV() end
+    function fs.SetWordWrap() end
+    function fs.SetWidth() end
+
+    function fs:SetText(text)
+        self._text = text or ""
+    end
+
+    function fs:GetText()
+        return self._text
+    end
+
+    function fs:GetStringWidth()
+        return #self._text * 7
+    end
+
+    return fs
+end
+
+-------------------------------------------------------------------------------
+-- Mock frame
+-------------------------------------------------------------------------------
+
+local function CreateMockFrame()
+    local frame = {
+        _points = {},
+        _shown = false,
+        _size = { w = 0, h = 0 },
+        _scripts = {},
+        _alpha = 1,
+        _backdrop = nil,
+        _backdropColor = nil,
+        _backdropBorderColor = nil,
+    }
+
+    function frame:SetPoint(point, relativeTo, relativePoint, x, y)
+        self._points[#self._points + 1] = {
+            point = point,
+            relativeTo = relativeTo,
+            relativePoint = relativePoint,
+            x = x,
+            y = y,
+        }
+    end
+
+    function frame:ClearAllPoints()
+        self._points = {}
+    end
+
+    function frame:Show()
+        self._shown = true
+    end
+
+    function frame:Hide()
+        self._shown = false
+    end
+
+    function frame:IsShown()
+        return self._shown
+    end
+
+    function frame:SetSize(w, h)
+        self._size = { w = w, h = h }
+    end
+
+    function frame:SetHeight(h)
+        self._size.h = h
+    end
+
+    function frame:SetWidth(w)
+        self._size.w = w
+    end
+
+    function frame:GetWidth()
+        return self._size.w
+    end
+
+    function frame:GetHeight()
+        return self._size.h
+    end
+
+    function frame:SetAlpha(a)
+        self._alpha = a
+    end
+
+    function frame:GetAlpha()
+        return self._alpha
+    end
+
+    function frame:SetBackdrop(bd)
+        self._backdrop = bd
+    end
+
+    function frame:SetBackdropColor(r, g, b, a)
+        self._backdropColor = { r, g, b, a }
+    end
+
+    function frame:SetBackdropBorderColor(r, g, b, a)
+        self._backdropBorderColor = { r, g, b, a }
+    end
+
+    function frame.EnableMouse() end
+    function frame.SetMovable() end
+    function frame.SetClampedToScreen() end
+    function frame.StartMoving() end
+    function frame.StopMovingOrSizing() end
+    function frame.SetFrameStrata() end
+    function frame.SetFrameLevel() end
+    function frame.RegisterForDrag() end
+
+    function frame:CreateTexture() -- luacheck: ignore 212/self
+        return CreateMockTexture()
+    end
+
+    function frame:CreateFontString() -- luacheck: ignore 212/self
+        return CreateMockFontString()
+    end
+
+    function frame:SetScript(event, handler)
+        self._scripts[event] = handler
+    end
+
+    return frame
+end
+
+function CreateFrame(_, _, _, _)
+    return CreateMockFrame()
+end
+
+UIParent = CreateMockFrame()
+
+-- luacheck: pop
+
+-------------------------------------------------------------------------------
+-- Shared file loader
+-------------------------------------------------------------------------------
+
+local function load(path)
+    local chunk, err = loadfile(path)
+    if not chunk then error("Failed to load " .. path .. ": " .. (err or "unknown")) end
+    chunk()
+end
+
+-------------------------------------------------------------------------------
+-- Module loader
+-------------------------------------------------------------------------------
+
+function M.LoadDragonWidgets()
+    -- Must set DragonWidgetsNS global before loading any widget file
+    DragonWidgetsNS = { Widgets = {} } -- luacheck: ignore 111 112
+
+    load("DragonWidgets/DragonWidgets.lua")
+    load("DragonWidgets/Widgets/WidgetConstants.lua")
+    return DragonWidgetsNS -- luacheck: ignore 113
+end
+
+function M.LoadWidget(widgetFile)
+    load("DragonWidgets/Widgets/" .. widgetFile)
+    return DragonWidgetsNS.Widgets -- luacheck: ignore 113
+end
+
+-------------------------------------------------------------------------------
+-- Reload (clears event bus by re-executing DragonWidgets.lua)
+-------------------------------------------------------------------------------
+
+function M.Reload()
+    return M.LoadDragonWidgets()
+end
+
+return M


### PR DESCRIPTION
## Summary

Closes #4.

Adds a complete busted unit test infrastructure to DragonWidgets. No tests existed before.

## New files

- `.busted` - config pointing at `spec/` directory, using `lua` binary (matches CI)
- `.mise.toml` - Lua 5.1 toolchain + `test` and `lint` task shortcuts
- `spec/wow_mock.lua` - lightweight WoW API mock (CreateFrame, GameTooltip, LibStub, UISpecialFrames, module loaders for DragonWidgets + individual widgets)
- `spec/EventBus_spec.lua` - 6 tests for the `ns.On`/`ns.Fire` event bus
- `spec/Toggle_spec.lua` - 15 tests for `CreateToggle` (GetValue, SetValue, SetDisabled, Refresh, click handling, event firing)

## Test results

```
21 successes / 0 failures / 0 errors
```

## Type of change
- [x] New feature (test infrastructure)

## Checklist
- [x] luacheck passes (0 warnings)
- [x] busted passes (21/21)
- [x] Tests run with `mise run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites to improve code quality and reliability

* **Chores**
  * Added development tool configuration for automated testing and code quality checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->