### PR TITLE
test: expand widget test coverage to all testable widgets (#9)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,43 +1,70 @@
 -- DragonWidgets Luacheck configuration
 std = "lua51"
 max_line_length = 120
+codes = true
 
-globals = {
-    "DragonWidgetsNS",
-    "ColorPickerFrame",
+exclude_files = {
+    ".release/",
+}
+
+ignore = {
+    "212/self",
+    "211/_.*",  -- unused variables prefixed with underscore
+    "213/_.*",  -- unused loop variables prefixed with underscore
 }
 
 read_globals = {
-    -- WoW API
+    -- Lua
+    "table", "string", "math", "pairs", "ipairs", "type", "tostring", "tonumber",
+    "pcall", "error", "print", "unpack", "select", "next",
+    "rawget", "rawset", "setmetatable", "getmetatable",
+
+    -- WoW API (shared across addon + spec)
     "CreateFrame",
     "UIParent",
-    "UISpecialFrames",
     "GameTooltip",
-    "ShowUIPanel",
-    "PlaySound",
-    "SOUNDKIT",
-    "GetCursorInfo",
-    "ClearCursor",
-    "GetItemInfo",
-    "C_Item",
-    "C_Timer",
     "LibStub",
-    "table",
-    "math",
-    "string",
-    "pairs",
-    "ipairs",
-    "type",
-    "tostring",
-    "tonumber",
-    "pcall",
-    "error",
-    "print",
-    "unpack",
-    "select",
-    "next",
-    "rawget",
-    "rawset",
-    "setmetatable",
-    "getmetatable",
+}
+
+-----------------------------------------------------------------------
+-- DragonWidgets (addon source)
+-----------------------------------------------------------------------
+files["DragonWidgets/"] = {
+    globals = {
+        "DragonWidgetsNS",
+        "ColorPickerFrame",
+    },
+
+    read_globals = {
+        -- WoW API
+        "UISpecialFrames",
+        "ShowUIPanel",
+        "PlaySound",
+        "SOUNDKIT",
+        "GetCursorInfo",
+        "ClearCursor",
+        "GetItemInfo",
+        "C_Item",
+        "C_Timer",
+    },
+}
+
+-----------------------------------------------------------------------
+-- Tests
+-----------------------------------------------------------------------
+files["spec/"] = {
+    std = "+busted",
+    globals = {
+        -- WoW API mocks (set as globals in wow_mock.lua)
+        "CreateFrame",
+        "UIParent",
+        "UISpecialFrames",
+        "GameTooltip",
+        "LibStub",
+        "PlaySound",
+        "SOUNDKIT",
+        "DragonWidgetsNS",
+        "ColorPickerFrame",
+        "ShowUIPanel",
+    },
 }

--- a/spec/Button_spec.lua
+++ b/spec/Button_spec.lua
@@ -1,0 +1,125 @@
+-------------------------------------------------------------------------------
+-- Button_spec.lua
+-- Tests for ns.Widgets.CreateButton
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Button", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("Button.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Creation
+    ---------------------------------------------------------------------------
+
+    describe("creation", function()
+        it("creates without error", function()
+            assert.has_no.errors(function()
+                ns.Widgets.CreateButton(parentFrame, {
+                    text = "Click Me",
+                    key = "testKey",
+                })
+            end)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetDisabled
+    ---------------------------------------------------------------------------
+
+    describe("SetDisabled", function()
+        it("can be called without error", function()
+            local btn = ns.Widgets.CreateButton(parentFrame, {
+                text = "Click Me",
+                key = "testKey",
+            })
+
+            assert.has_no.errors(function()
+                btn:SetDisabled(true)
+            end)
+
+            assert.has_no.errors(function()
+                btn:SetDisabled(false)
+            end)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- OnClick
+    ---------------------------------------------------------------------------
+
+    describe("OnClick", function()
+        it("fires OnWidgetChanged with correct payload", function()
+            local receivedPayload
+            ns.On("OnWidgetChanged", function(payload)
+                receivedPayload = payload
+            end)
+
+            local btn = ns.Widgets.CreateButton(parentFrame, {
+                text = "Click Me",
+                key = "myButtonKey",
+            })
+
+            local onClick = btn._scripts["OnClick"]
+            onClick(btn)
+
+            assert.is_not_nil(receivedPayload)
+            assert.are.equal("Button", receivedPayload.widgetType)
+            assert.are.equal("myButtonKey", receivedPayload.key)
+        end)
+
+        it("calls opts.onClick callback", function()
+            local clickCalled = false
+            local btn = ns.Widgets.CreateButton(parentFrame, {
+                text = "Click Me",
+                key = "testKey",
+                onClick = function() clickCalled = true end,
+            })
+
+            local onClick = btn._scripts["OnClick"]
+            onClick(btn)
+
+            assert.is_true(clickCalled)
+        end)
+
+        it("does not fire OnWidgetChanged when disabled", function()
+            local eventFired = false
+            ns.On("OnWidgetChanged", function()
+                eventFired = true
+            end)
+
+            local btn = ns.Widgets.CreateButton(parentFrame, {
+                text = "Click Me",
+                key = "testKey",
+            })
+
+            btn:SetDisabled(true)
+            local onClick = btn._scripts["OnClick"]
+            onClick(btn)
+
+            assert.is_false(eventFired)
+        end)
+
+        it("does not call opts.onClick when disabled", function()
+            local clickCalled = false
+            local btn = ns.Widgets.CreateButton(parentFrame, {
+                text = "Click Me",
+                key = "testKey",
+                onClick = function() clickCalled = true end,
+            })
+
+            btn:SetDisabled(true)
+            local onClick = btn._scripts["OnClick"]
+            onClick(btn)
+
+            assert.is_false(clickCalled)
+        end)
+    end)
+end)

--- a/spec/ColorPicker_spec.lua
+++ b/spec/ColorPicker_spec.lua
@@ -1,0 +1,203 @@
+-------------------------------------------------------------------------------
+-- ColorPicker_spec.lua
+-- Tests for ns.Widgets.CreateColorPicker
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("ColorPicker", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("ColorPicker.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    ---------------------------------------------------------------------------
+    -- GetValue
+    ---------------------------------------------------------------------------
+
+    describe("GetValue", function()
+        it("returns (1, 1, 1, 1) initially when no opts.get is provided", function()
+            local widget = ns.Widgets.CreateColorPicker(parentFrame, {
+                label = "Test Color",
+                key = "testKey",
+            })
+
+            local r, g, b, a = widget:GetValue()
+
+            assert.are.equal(1, r)
+            assert.are.equal(1, g)
+            assert.are.equal(1, b)
+            assert.are.equal(1, a)
+        end)
+
+        it("returns opts.get() values when provided", function()
+            local widget = ns.Widgets.CreateColorPicker(parentFrame, {
+                label = "Test Color",
+                key = "testKey",
+                get = function() return 0.5, 0.3, 0.8, 0.9 end,
+            })
+
+            local r, g, b, a = widget:GetValue()
+
+            assert.are.equal(0.5, r)
+            assert.are.equal(0.3, g)
+            assert.are.equal(0.8, b)
+            assert.are.equal(0.9, a)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetValue
+    ---------------------------------------------------------------------------
+
+    describe("SetValue", function()
+        it("GetValue returns updated r, g, b, a values", function()
+            local storedR, storedG, storedB, storedA = 1, 1, 1, 1
+            local widget = ns.Widgets.CreateColorPicker(parentFrame, {
+                label = "Test Color",
+                key = "testKey",
+                get = function() return storedR, storedG, storedB, storedA end,
+                set = function(r, g, b, a)
+                    storedR, storedG, storedB, storedA = r, g, b, a
+                end,
+            })
+
+            widget:SetValue(0.2, 0.4, 0.6, 0.8)
+
+            local r, g, b, a = widget:GetValue()
+            assert.are.equal(0.2, r)
+            assert.are.equal(0.4, g)
+            assert.are.equal(0.6, b)
+            assert.are.equal(0.8, a)
+        end)
+
+        it("does NOT fire OnWidgetChanged", function()
+            local eventFired = false
+            ns.On("OnWidgetChanged", function()
+                eventFired = true
+            end)
+
+            local widget = ns.Widgets.CreateColorPicker(parentFrame, {
+                label = "Test Color",
+                key = "testKey",
+            })
+
+            widget:SetValue(0.5, 0.5, 0.5, 1.0)
+
+            assert.is_false(eventFired)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetDisabled
+    ---------------------------------------------------------------------------
+
+    describe("SetDisabled", function()
+        it("can be called without error", function()
+            local widget = ns.Widgets.CreateColorPicker(parentFrame, {
+                label = "Test Color",
+                key = "testKey",
+            })
+
+            assert.has_no.errors(function()
+                widget:SetDisabled(true)
+            end)
+
+            assert.has_no.errors(function()
+                widget:SetDisabled(false)
+            end)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Refresh
+    ---------------------------------------------------------------------------
+
+    describe("Refresh", function()
+        it("re-reads from opts.get()", function()
+            local externalR, externalG, externalB, externalA = 1, 0, 0, 1
+            local widget = ns.Widgets.CreateColorPicker(parentFrame, {
+                label = "Test Color",
+                key = "testKey",
+                get = function() return externalR, externalG, externalB, externalA end,
+            })
+
+            local r, g, b, a = widget:GetValue()
+            assert.are.equal(1, r)
+            assert.are.equal(0, g)
+            assert.are.equal(0, b)
+            assert.are.equal(1, a)
+
+            externalR, externalG, externalB, externalA = 0, 1, 0, 0.5
+
+            widget:Refresh()
+
+            r, g, b, a = widget:GetValue()
+            assert.are.equal(0, r)
+            assert.are.equal(1, g)
+            assert.are.equal(0, b)
+            assert.are.equal(0.5, a)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- swatchFunc callback
+    ---------------------------------------------------------------------------
+
+    describe("swatchFunc callback", function()
+        local function triggerSwatchFunc(widget, r, g, b, a)
+            ColorPickerFrame._r = r or 1   -- luacheck: ignore 113
+            ColorPickerFrame._g = g or 1   -- luacheck: ignore 113
+            ColorPickerFrame._b = b or 1   -- luacheck: ignore 113
+            ColorPickerFrame._a = a or 1   -- luacheck: ignore 113
+            local onMouseUp = widget._border._scripts["OnMouseUp"]
+            if onMouseUp then onMouseUp(widget._border, "LeftButton") end
+            if ColorPickerFrame._swatchFunc then   -- luacheck: ignore 113
+                ColorPickerFrame._swatchFunc()     -- luacheck: ignore 113
+            end
+        end
+
+        it("fires OnWidgetChanged with correct payload", function()
+            local receivedPayload
+            ns.On("OnWidgetChanged", function(payload)
+                receivedPayload = payload
+            end)
+
+            local widget = ns.Widgets.CreateColorPicker(parentFrame, {
+                label = "Test Color",
+                key = "myColorKey",
+            })
+
+            triggerSwatchFunc(widget, 0.2, 0.4, 0.6, 1.0)
+
+            assert.is_not_nil(receivedPayload)
+            assert.are.equal("ColorPicker", receivedPayload.widgetType)
+            assert.are.equal("myColorKey", receivedPayload.key)
+            assert.are.equal(0.2, receivedPayload.value.r)
+            assert.are.equal(0.4, receivedPayload.value.g)
+            assert.are.equal(0.6, receivedPayload.value.b)
+            assert.are.equal(1.0, receivedPayload.value.a)
+        end)
+
+        it("fires OnAppearanceChanged when isAppearance is true", function()
+            local appearanceFired = false
+            ns.On("OnAppearanceChanged", function()
+                appearanceFired = true
+            end)
+
+            local widget = ns.Widgets.CreateColorPicker(parentFrame, {
+                label = "Test Color",
+                key = "testKey",
+                isAppearance = true,
+            })
+
+            triggerSwatchFunc(widget, 1, 1, 1, 1)
+
+            assert.is_true(appearanceFired)
+        end)
+    end)
+end)

--- a/spec/Description_spec.lua
+++ b/spec/Description_spec.lua
@@ -1,0 +1,46 @@
+-------------------------------------------------------------------------------
+-- Description_spec.lua
+-- Tests for ns.Widgets.CreateDescription
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Description", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("Description.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Widget creation
+    ---------------------------------------------------------------------------
+
+    describe("creation", function()
+        it("returns a frame", function()
+            local frame = ns.Widgets.CreateDescription(parentFrame, "some text")
+
+            assert.is_not_nil(frame)
+            assert.is_not_nil(frame.SetHeight)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetText
+    ---------------------------------------------------------------------------
+
+    describe("SetText", function()
+        it("updates the internal font string text", function()
+            local frame = ns.Widgets.CreateDescription(parentFrame, "original text")
+
+            assert.are.equal("original text", frame._fontString:GetText())
+
+            frame:SetText("new text")
+
+            assert.are.equal("new text", frame._fontString:GetText())
+        end)
+    end)
+end)

--- a/spec/Dropdown_spec.lua
+++ b/spec/Dropdown_spec.lua
@@ -1,0 +1,142 @@
+-------------------------------------------------------------------------------
+-- Dropdown_spec.lua
+-- Tests for ns.Widgets.CreateDropdown
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Dropdown", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        -- Dropdown depends on ScrollFrame internally (CreateScrollFrame call)
+        mock.LoadWidget("ScrollFrame.lua")
+        mock.LoadWidget("Dropdown.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    ---------------------------------------------------------------------------
+    -- GetValue
+    ---------------------------------------------------------------------------
+
+    describe("GetValue", function()
+        it("returns nil initially when no opts.get is provided", function()
+            local dropdown = ns.Widgets.CreateDropdown(parentFrame, {
+                label = "Test Dropdown",
+                key = "testKey",
+                values = { { text = "One", value = 1 } },
+            })
+
+            assert.is_nil(dropdown:GetValue())
+        end)
+
+        it("returns opts.get() value when provided", function()
+            local dropdown = ns.Widgets.CreateDropdown(parentFrame, {
+                label = "Test Dropdown",
+                key = "testKey",
+                values = { { text = "One", value = 1 }, { text = "Two", value = 2 } },
+                get = function() return 2 end,
+            })
+
+            assert.are.equal(2, dropdown:GetValue())
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetValue
+    ---------------------------------------------------------------------------
+
+    describe("SetValue", function()
+        it("stores value and GetValue returns new value", function()
+            local storedValue = nil
+            local dropdown = ns.Widgets.CreateDropdown(parentFrame, {
+                label = "Test Dropdown",
+                key = "testKey",
+                values = { { text = "One", value = 1 }, { text = "Two", value = 2 } },
+                get = function() return storedValue end,
+                set = function(v) storedValue = v end,
+            })
+
+            dropdown:SetValue(2)
+
+            assert.are.equal(2, dropdown:GetValue())
+        end)
+
+        it("does not fire OnWidgetChanged event", function()
+            local eventFired = false
+            ns.On("OnWidgetChanged", function()
+                eventFired = true
+            end)
+
+            local storedValue = nil
+            local dropdown = ns.Widgets.CreateDropdown(parentFrame, {
+                label = "Test Dropdown",
+                key = "testKey",
+                values = { { text = "A", value = "a" } },
+                get = function() return storedValue end,
+                set = function(v) storedValue = v end,
+            })
+
+            dropdown:SetValue("a")
+
+            assert.is_false(eventFired)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetDisabled
+    ---------------------------------------------------------------------------
+
+    describe("SetDisabled", function()
+        it("can be called with true without error", function()
+            local dropdown = ns.Widgets.CreateDropdown(parentFrame, {
+                label = "Test Dropdown",
+                key = "testKey",
+                values = { { text = "One", value = 1 } },
+            })
+
+            assert.has_no.errors(function()
+                dropdown:SetDisabled(true)
+            end)
+        end)
+
+        it("can be called with false without error", function()
+            local dropdown = ns.Widgets.CreateDropdown(parentFrame, {
+                label = "Test Dropdown",
+                key = "testKey",
+                values = { { text = "One", value = 1 } },
+            })
+
+            dropdown:SetDisabled(true)
+
+            assert.has_no.errors(function()
+                dropdown:SetDisabled(false)
+            end)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Refresh
+    ---------------------------------------------------------------------------
+
+    describe("Refresh", function()
+        it("re-reads from opts.get()", function()
+            local externalValue = 1
+            local dropdown = ns.Widgets.CreateDropdown(parentFrame, {
+                label = "Test Dropdown",
+                key = "testKey",
+                values = { { text = "One", value = 1 }, { text = "Two", value = 2 } },
+                get = function() return externalValue end,
+            })
+
+            assert.are.equal(1, dropdown:GetValue())
+
+            externalValue = 2
+            dropdown:Refresh()
+
+            assert.are.equal(2, dropdown:GetValue())
+        end)
+    end)
+end)

--- a/spec/Header_spec.lua
+++ b/spec/Header_spec.lua
@@ -1,0 +1,42 @@
+-------------------------------------------------------------------------------
+-- Header_spec.lua
+-- Tests for ns.Widgets.CreateHeader
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Header", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("Header.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Widget creation
+    ---------------------------------------------------------------------------
+
+    describe("creation", function()
+        it("returns a frame", function()
+            local frame = ns.Widgets.CreateHeader(parentFrame, "Header Text")
+
+            assert.is_not_nil(frame)
+            assert.is_not_nil(frame.SetHeight)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Font string text
+    ---------------------------------------------------------------------------
+
+    describe("font string", function()
+        it("text matches the constructor argument", function()
+            local frame = ns.Widgets.CreateHeader(parentFrame, "My Header")
+
+            assert.are.equal("My Header", frame._fontString:GetText())
+        end)
+    end)
+end)

--- a/spec/Panel_spec.lua
+++ b/spec/Panel_spec.lua
@@ -1,0 +1,40 @@
+-------------------------------------------------------------------------------
+-- Panel_spec.lua
+-- Tests for ns.Widgets.CreatePanel
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Panel", function()
+    local ns
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("Panel.lua")
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Widget creation
+    ---------------------------------------------------------------------------
+
+    describe("creation", function()
+        it("returns a frame", function()
+            local panel = ns.Widgets.CreatePanel("TestPanel", 800, 600)
+
+            assert.is_not_nil(panel)
+            assert.is_not_nil(panel.SetHeight)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetTitle
+    ---------------------------------------------------------------------------
+
+    describe("SetTitle", function()
+        it("updates the title text", function()
+            local panel = ns.Widgets.CreatePanel("TestPanel", 800, 600)
+            panel:SetTitle("My Panel Title")
+            assert.are.equal("My Panel Title", panel.titleBar.text._text)
+        end)
+    end)
+end)

--- a/spec/Section_spec.lua
+++ b/spec/Section_spec.lua
@@ -1,0 +1,57 @@
+-------------------------------------------------------------------------------
+-- Section_spec.lua
+-- Tests for ns.Widgets.CreateSection
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Section", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("Section.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Widget creation
+    ---------------------------------------------------------------------------
+
+    describe("creation", function()
+        it("returns a frame", function()
+            local frame = ns.Widgets.CreateSection(parentFrame, "Section Header")
+
+            assert.is_not_nil(frame)
+            assert.is_not_nil(frame.SetHeight)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Content property
+    ---------------------------------------------------------------------------
+
+    describe("content", function()
+        it("exists and is a frame", function()
+            local frame = ns.Widgets.CreateSection(parentFrame, "Section Header")
+
+            assert.is_not_nil(frame.content)
+            assert.is_not_nil(frame.content.SetHeight)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetContentHeight
+    ---------------------------------------------------------------------------
+
+    describe("SetContentHeight", function()
+        it("can be called without error", function()
+            local frame = ns.Widgets.CreateSection(parentFrame, "Section Header")
+
+            assert.has_no.errors(function()
+                frame:SetContentHeight(100)
+            end)
+        end)
+    end)
+end)

--- a/spec/Slider_spec.lua
+++ b/spec/Slider_spec.lua
@@ -1,0 +1,390 @@
+-------------------------------------------------------------------------------
+-- Slider_spec.lua
+-- Tests for ns.Widgets.CreateSlider
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("Slider", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("Slider.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    ---------------------------------------------------------------------------
+    -- GetValue
+    ---------------------------------------------------------------------------
+
+    describe("GetValue", function()
+        it("returns opts.min initially when no opts.get is provided", function()
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 5,
+                max = 100,
+            })
+
+            assert.are.equal(5, slider:GetValue())
+        end)
+
+        it("returns opts.get() value when provided", function()
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+                get = function() return 42 end,
+            })
+
+            assert.are.equal(42, slider:GetValue())
+        end)
+
+        it("returns opts.min when opts.get is not provided", function()
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 10,
+                max = 50,
+            })
+
+            assert.are.equal(10, slider:GetValue())
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetValue
+    ---------------------------------------------------------------------------
+
+    describe("SetValue", function()
+        it("clamps to max", function()
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+            })
+
+            slider:SetValue(200)
+
+            assert.are.equal(100, slider:GetValue())
+        end)
+
+        it("clamps to min", function()
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 10,
+                max = 100,
+            })
+
+            slider:SetValue(-5)
+
+            assert.are.equal(10, slider:GetValue())
+        end)
+
+        it("rounds to step", function()
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+                step = 5,
+            })
+
+            slider:SetValue(17)
+
+            assert.are.equal(15, slider:GetValue())
+        end)
+
+        it("does NOT call opts.set", function()
+            local setCalled = false
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+                set = function() setCalled = true end,
+            })
+
+            slider:SetValue(50)
+
+            assert.is_false(setCalled)
+        end)
+
+        it("does NOT fire events", function()
+            local eventFired = false
+            ns.On("OnWidgetChanged", function()
+                eventFired = true
+            end)
+
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+            })
+
+            slider:SetValue(50)
+
+            assert.is_false(eventFired)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetDisabled
+    ---------------------------------------------------------------------------
+
+    describe("SetDisabled", function()
+        it("dims state without error", function()
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+            })
+
+            assert.has_no.errors(function()
+                slider:SetDisabled(true)
+            end)
+        end)
+
+        it("re-enables without error", function()
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+            })
+
+            slider:SetDisabled(true)
+
+            assert.has_no.errors(function()
+                slider:SetDisabled(false)
+            end)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Refresh
+    ---------------------------------------------------------------------------
+
+    describe("Refresh", function()
+        it("re-reads from opts.get()", function()
+            local externalValue = 20
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+                get = function() return externalValue end,
+            })
+
+            assert.are.equal(20, slider:GetValue())
+
+            externalValue = 75
+            slider:Refresh()
+
+            assert.are.equal(75, slider:GetValue())
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- OnValueChanged (slider script)
+    ---------------------------------------------------------------------------
+
+    describe("OnValueChanged", function()
+        it("fires OnWidgetChanged with correct payload", function()
+            local receivedPayload
+            ns.On("OnWidgetChanged", function(payload)
+                receivedPayload = payload
+            end)
+
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "mySliderKey",
+                min = 0,
+                max = 100,
+                step = 1,
+            })
+
+            local onValueChanged = slider._slider._scripts["OnValueChanged"]
+            onValueChanged(slider._slider, 42)
+
+            assert.is_not_nil(receivedPayload)
+            assert.are.equal("Slider", receivedPayload.widgetType)
+            assert.are.equal("mySliderKey", receivedPayload.key)
+            assert.are.equal(42, receivedPayload.value)
+        end)
+
+        it("fires OnAppearanceChanged when isAppearance is true", function()
+            local appearanceFired = false
+            ns.On("OnAppearanceChanged", function()
+                appearanceFired = true
+            end)
+
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+                isAppearance = true,
+            })
+
+            local onValueChanged = slider._slider._scripts["OnValueChanged"]
+            onValueChanged(slider._slider, 50)
+
+            assert.is_true(appearanceFired)
+        end)
+
+        it("does NOT fire OnAppearanceChanged when isAppearance is nil", function()
+            local appearanceFired = false
+            ns.On("OnAppearanceChanged", function()
+                appearanceFired = true
+            end)
+
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+            })
+
+            local onValueChanged = slider._slider._scripts["OnValueChanged"]
+            onValueChanged(slider._slider, 50)
+
+            assert.is_false(appearanceFired)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- EditBox OnEnterPressed
+    ---------------------------------------------------------------------------
+
+    describe("EditBox OnEnterPressed", function()
+        it("parses typed value, clamps, calls opts.set, fires OnWidgetChanged", function()
+            local receivedSetValue
+            local receivedPayload
+            ns.On("OnWidgetChanged", function(payload)
+                receivedPayload = payload
+            end)
+
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "mySliderKey",
+                min = 0,
+                max = 100,
+                step = 1,
+                set = function(v) receivedSetValue = v end,
+            })
+
+            slider._editBox:SetText("75")
+            local onEnterPressed = slider._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(slider._editBox)
+
+            assert.are.equal(75, receivedSetValue)
+            assert.is_not_nil(receivedPayload)
+            assert.are.equal("Slider", receivedPayload.widgetType)
+            assert.are.equal("mySliderKey", receivedPayload.key)
+            assert.are.equal(75, receivedPayload.value)
+        end)
+
+        it("clamps typed value to max", function()
+            local receivedSetValue
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+                step = 1,
+                set = function(v) receivedSetValue = v end,
+            })
+
+            slider._editBox:SetText("999")
+            local onEnterPressed = slider._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(slider._editBox)
+
+            assert.are.equal(100, receivedSetValue)
+        end)
+
+        it("ignores non-numeric input and does not call opts.set", function()
+            local setCalled = false
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+                set = function() setCalled = true end,
+            })
+
+            slider._editBox:SetText("abc")
+            local onEnterPressed = slider._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(slider._editBox)
+
+            assert.is_false(setCalled)
+        end)
+
+        it("handles percent format by stripping % and dividing by 100", function()
+            local receivedSetValue
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 1,
+                step = 0.01,
+                isPercent = true,
+                set = function(v) receivedSetValue = v end,
+            })
+
+            slider._editBox:SetText("75%")
+            local onEnterPressed = slider._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(slider._editBox)
+
+            assert.are.equal(0.75, receivedSetValue)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- EditBox OnEscapePressed
+    ---------------------------------------------------------------------------
+
+    describe("EditBox OnEscapePressed", function()
+        it("does not call opts.set", function()
+            local setCalled = false
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+                set = function() setCalled = true end,
+            })
+
+            local onEscapePressed = slider._editBox._scripts["OnEscapePressed"]
+            onEscapePressed(slider._editBox)
+
+            assert.is_false(setCalled)
+        end)
+
+        it("does not fire events", function()
+            local eventFired = false
+            ns.On("OnWidgetChanged", function()
+                eventFired = true
+            end)
+
+            local slider = ns.Widgets.CreateSlider(parentFrame, {
+                label = "Test Slider",
+                key = "testKey",
+                min = 0,
+                max = 100,
+            })
+
+            local onEscapePressed = slider._editBox._scripts["OnEscapePressed"]
+            onEscapePressed(slider._editBox)
+
+            assert.is_false(eventFired)
+        end)
+    end)
+end)

--- a/spec/TextInput_spec.lua
+++ b/spec/TextInput_spec.lua
@@ -1,0 +1,254 @@
+-------------------------------------------------------------------------------
+-- TextInput_spec.lua
+-- Tests for ns.Widgets.CreateTextInput
+-------------------------------------------------------------------------------
+
+local mock = require("spec.wow_mock")
+
+describe("TextInput", function()
+    local ns
+    local parentFrame
+
+    before_each(function()
+        ns = mock.Reload()
+        mock.LoadWidget("TextInput.lua")
+        parentFrame = CreateFrame("Frame") -- luacheck: ignore 113
+    end)
+
+    ---------------------------------------------------------------------------
+    -- GetValue
+    ---------------------------------------------------------------------------
+
+    describe("GetValue", function()
+        it("returns empty string initially when no opts.get is provided", function()
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+            })
+
+            assert.are.equal("", widget:GetValue())
+        end)
+
+        it("returns opts.get() value when provided", function()
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+                get = function() return "hello world" end,
+            })
+
+            assert.are.equal("hello world", widget:GetValue())
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetValue
+    ---------------------------------------------------------------------------
+
+    describe("SetValue", function()
+        it("sets value and GetValue returns it", function()
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+            })
+
+            widget:SetValue("new text")
+
+            assert.are.equal("new text", widget:GetValue())
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- SetDisabled
+    ---------------------------------------------------------------------------
+
+    describe("SetDisabled", function()
+        it("when disabled, OnEnterPressed does not call opts.set", function()
+            local setCalled = false
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+                set = function() setCalled = true end,
+            })
+
+            widget:SetDisabled(true)
+            widget._editBox:SetText("typed text")
+            local onEnterPressed = widget._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(widget._editBox)
+
+            assert.is_false(setCalled)
+        end)
+
+        it("when disabled, OnEnterPressed does not fire events", function()
+            local eventFired = false
+            ns.On("OnWidgetChanged", function()
+                eventFired = true
+            end)
+
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+            })
+
+            widget:SetDisabled(true)
+            widget._editBox:SetText("typed text")
+            local onEnterPressed = widget._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(widget._editBox)
+
+            assert.is_false(eventFired)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- Refresh
+    ---------------------------------------------------------------------------
+
+    describe("Refresh", function()
+        it("re-reads from opts.get()", function()
+            local externalValue = "initial"
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+                get = function() return externalValue end,
+            })
+
+            assert.are.equal("initial", widget:GetValue())
+
+            externalValue = "updated"
+            widget:Refresh()
+
+            assert.are.equal("updated", widget:GetValue())
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- OnEnterPressed
+    ---------------------------------------------------------------------------
+
+    describe("OnEnterPressed", function()
+        it("calls opts.set with text", function()
+            local receivedValue
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+                set = function(v) receivedValue = v end,
+            })
+
+            widget._editBox:SetText("submitted text")
+            local onEnterPressed = widget._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(widget._editBox)
+
+            assert.are.equal("submitted text", receivedValue)
+        end)
+
+        it("fires OnWidgetChanged with correct payload", function()
+            local receivedPayload
+            ns.On("OnWidgetChanged", function(payload)
+                receivedPayload = payload
+            end)
+
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "myInputKey",
+            })
+
+            widget._editBox:SetText("test value")
+            local onEnterPressed = widget._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(widget._editBox)
+
+            assert.is_not_nil(receivedPayload)
+            assert.are.equal("TextInput", receivedPayload.widgetType)
+            assert.are.equal("myInputKey", receivedPayload.key)
+            assert.are.equal("test value", receivedPayload.value)
+        end)
+
+        it("fires OnAppearanceChanged when isAppearance is true", function()
+            local appearanceFired = false
+            ns.On("OnAppearanceChanged", function()
+                appearanceFired = true
+            end)
+
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+                isAppearance = true,
+            })
+
+            widget._editBox:SetText("value")
+            local onEnterPressed = widget._editBox._scripts["OnEnterPressed"]
+            onEnterPressed(widget._editBox)
+
+            assert.is_true(appearanceFired)
+        end)
+
+        it("clears focus after submit", function()
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+            })
+
+            -- ClearFocus is a no-op stub; verify it does not error
+            widget._editBox:SetText("value")
+            local onEnterPressed = widget._editBox._scripts["OnEnterPressed"]
+
+            assert.has_no.errors(function()
+                onEnterPressed(widget._editBox)
+            end)
+        end)
+    end)
+
+    ---------------------------------------------------------------------------
+    -- OnEscapePressed
+    ---------------------------------------------------------------------------
+
+    describe("OnEscapePressed", function()
+        it("reverts to opts.get() value", function()
+            local externalValue = "original"
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+                get = function() return externalValue end,
+            })
+
+            widget._editBox:SetText("unsaved changes")
+            local onEscapePressed = widget._editBox._scripts["OnEscapePressed"]
+            onEscapePressed(widget._editBox)
+
+            assert.are.equal("original", widget:GetValue())
+        end)
+
+        it("does not call opts.set", function()
+            local setCalled = false
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+                get = function() return "stored" end,
+                set = function() setCalled = true end,
+            })
+
+            widget._editBox:SetText("unsaved")
+            local onEscapePressed = widget._editBox._scripts["OnEscapePressed"]
+            onEscapePressed(widget._editBox)
+
+            assert.is_false(setCalled)
+        end)
+
+        it("does not fire events", function()
+            local eventFired = false
+            ns.On("OnWidgetChanged", function()
+                eventFired = true
+            end)
+
+            local widget = ns.Widgets.CreateTextInput(parentFrame, {
+                label = "Test Input",
+                key = "testKey",
+                get = function() return "stored" end,
+            })
+
+            widget._editBox:SetText("unsaved")
+            local onEscapePressed = widget._editBox._scripts["OnEscapePressed"]
+            onEscapePressed(widget._editBox)
+
+            assert.is_false(eventFired)
+        end)
+    end)
+end)

--- a/spec/wow_mock.lua
+++ b/spec/wow_mock.lua
@@ -113,6 +113,13 @@ local function CreateMockFontString()
         return #self._text * 7
     end
 
+    function fs:GetStringHeight()
+        return self._fontSize or 12
+    end
+
+    function fs.SetNonSpaceWrap() end
+    function fs.ClearAllPoints() end
+
     return fs
 end
 
@@ -206,6 +213,15 @@ local function CreateMockFrame()
     function frame.SetFrameStrata() end
     function frame.SetFrameLevel() end
     function frame.RegisterForDrag() end
+    function frame.SetAllPoints() end
+    function frame.SetScrollChild() end
+    function frame.SetVerticalScroll() end
+    function frame.EnableMouseWheel() end
+    function frame.SetNormalTexture() end
+    function frame.HookScript() end
+    function frame.SetFont() end
+    function frame.SetJustifyH() end
+    function frame.SetTextColor() end
 
     function frame:CreateTexture() -- luacheck: ignore 212/self
         return CreateMockTexture()
@@ -219,6 +235,38 @@ local function CreateMockFrame()
         self._scripts[event] = handler
     end
 
+    -- EditBox-specific methods (needed by Slider, TextInput)
+    function frame:SetAutoFocus() end
+    function frame:SetMaxLetters() end
+    function frame:SetTextInsets() end
+    function frame:ClearFocus() end
+    function frame:GetText()
+        return self._text or ""
+    end
+    function frame:SetText(text)
+        self._text = text or ""
+    end
+
+    -- Slider-specific methods
+    function frame:SetMinMaxValues(min, max)
+        self._min = min
+        self._max = max
+    end
+    function frame:SetValueStep() end
+    function frame:SetObeyStepOnDrag() end
+    function frame:SetOrientation() end
+    function frame:SetThumbTexture() end
+    function frame:SetValue(v)
+        self._value = v
+        -- Fire OnValueChanged script if registered
+        if self._scripts and self._scripts["OnValueChanged"] then
+            self._scripts["OnValueChanged"](self, v)
+        end
+    end
+    function frame:GetValue()
+        return self._value or 0
+    end
+
     return frame
 end
 
@@ -227,6 +275,40 @@ function CreateFrame(_, _, _, _)
 end
 
 UIParent = CreateMockFrame()
+
+-- ColorPickerFrame stub (needed by ColorPicker tests)
+ColorPickerFrame = {
+    _r = 1, _g = 1, _b = 1, _a = 1,
+    SetupColorPickerAndShow = function(self, info)
+        -- Retail API: info.r, info.g, info.b, info.opacity, info.hasOpacity, info.swatchFunc, info.cancelFunc
+        if info then
+            self._r = info.r or 1
+            self._g = info.g or 1
+            self._b = info.b or 1
+            self._a = info.opacity or 1
+            -- Store callbacks for test invocation
+            self._swatchFunc = info.swatchFunc
+            self._cancelFunc = info.cancelFunc
+        end
+    end,
+    GetColorRGB = function(self)
+        return self._r, self._g, self._b
+    end,
+    GetColorAlpha = function(self)
+        return self._a
+    end,
+    SetColorRGB = function(self, r, g, b)
+        self._r = r
+        self._g = g
+        self._b = b
+    end,
+    SetColorAlpha = function(self, a)
+        self._a = a
+    end,
+}
+
+-- ShowUIPanel stub (needed by ColorPicker classic API path)
+function ShowUIPanel() end
 
 -- luacheck: pop
 


### PR DESCRIPTION
## Summary
Extends the busted test suite to cover all remaining testable widgets.

## Changes
- Upgraded \.luacheckrc\ to file-scoped pattern matching DragonToast/DragonLoot conventions
- Extended \spec/wow_mock.lua\ with Slider, EditBox, and ColorPickerFrame stubs
- Added 9 new spec files: Slider, TextInput, Button, Dropdown, ColorPicker, Description, Header, Section, Panel

## Excluded widgets
ItemList, ItemSlot, TabGroup, ScrollFrame - depend on WoW layout/drag-drop APIs not mockable in unit tests

## Testing
- \luacheck .\: 0 warnings / 0 errors (29 files)
- \usted --verbose\: all tests pass

Closes #9